### PR TITLE
[REVIEW] Refactor to use EnvVars.expand for variable substitution

### DIFF
--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/Utils.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/Utils.java
@@ -24,12 +24,8 @@
 
 package com.gpuopenanalytics.jenkins.remotedocker;
 
-import hudson.model.AbstractBuild;
-import hudson.util.VariableResolver;
-
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -43,43 +39,23 @@ public class Utils {
 
     }
 
-
     /**
      * Finds <code>$VAR</code> or <code>${VAR}</code> in the specified string
      * that exist in the build's resolver and resolves them. If the variable is
      * not resolved, it is left unchanged.
      *
-     * @param build
+     * @param launcher
      * @param s
      * @return
      */
-    public static String resolveVariables(AbstractBuild build, String s) {
-        return resolveVariables(build.getBuildVariableResolver(), s);
-    }
-
-    /**
-     * Finds <code>$VAR</code> or <code>${VAR}</code> in the specified string
-     * that exist in the resolver and resolves them. If the variable is not
-     * resolved, it is left unchanged.
-     *
-     * @param resolver
-     * @param s
-     * @return
-     */
-    public static String resolveVariables(VariableResolver<String> resolver,
-                                          String s) {
-        //Matcher requires StringBuffer :(
-        StringBuffer sb = new StringBuffer();
-        Matcher m = VAR_REGEX.matcher(s);
-        while (m.find()) {
-            String varName = java.util.Optional.ofNullable(m.group(1))
-                    .orElseGet(() -> m.group(2));
-            String newValue = Optional.ofNullable(resolver.resolve(varName))
-                    .orElseGet(() -> "\\${" + varName + "}");
-            m.appendReplacement(sb, newValue);
+    public static String resolveVariables(DockerLauncher launcher, String s) {
+        try {
+            return launcher.getBuild()
+                    .getEnvironment(launcher.getListener())
+                    .expand(s);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
         }
-        m.appendTail(sb);
-        return sb.toString();
     }
 
     /**

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/CudaVersionConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/CudaVersionConfigItem.java
@@ -79,7 +79,7 @@ public class CudaVersionConfigItem extends ConfigItem {
                               ArgumentListBuilder args,
                               AbstractBuild build) {
         args.add("-e");
-        String cuda = Utils.resolveVariables(build, nvidiaCuda);
+        String cuda = Utils.resolveVariables(launcher, nvidiaCuda);
         args.addKeyValuePair("", ENV_VAR_NAME, "cuda>="+cuda, false);
     }
 

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/CustomConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/CustomConfigItem.java
@@ -24,8 +24,8 @@
 
 package com.gpuopenanalytics.jenkins.remotedocker.config;
 
+import com.gpuopenanalytics.jenkins.remotedocker.DockerLauncher;
 import com.gpuopenanalytics.jenkins.remotedocker.Utils;
-import hudson.model.AbstractBuild;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -76,8 +76,8 @@ public abstract class CustomConfigItem extends ConfigItem {
         return customValue.orElse(value);
     }
 
-    public String getResolvedValue(AbstractBuild<?,?> build) {
-        return Utils.resolveVariables(build, getValue());
+    public String getResolvedValue(DockerLauncher launcher) {
+        return Utils.resolveVariables(launcher, getValue());
     }
 
     /**

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/DockerRuntimeConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/DockerRuntimeConfigItem.java
@@ -61,7 +61,7 @@ public class DockerRuntimeConfigItem extends CustomConfigItem {
     public void addCreateArgs(DockerLauncher launcher,
                               ArgumentListBuilder args,
                               AbstractBuild build) {
-        args.addKeyValuePair("", "--runtime", getResolvedValue(build), false);
+        args.addKeyValuePair("", "--runtime", getResolvedValue(launcher), false);
     }
 
     @Extension

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/ExtraDockerArgsConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/ExtraDockerArgsConfigItem.java
@@ -64,7 +64,7 @@ public class ExtraDockerArgsConfigItem extends ConfigItem {
                               AbstractBuild build) {
         List<String> newArgs = Stream.of(
                 QuotedStringTokenizer.tokenize(extraArgs))
-                .map(s -> Utils.resolveVariables(build, s))
+                .map(s -> Utils.resolveVariables(launcher, s))
                 .collect(Collectors.toList());
         args.add(newArgs);
     }

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/MemoryConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/MemoryConfigItem.java
@@ -69,8 +69,7 @@ public class MemoryConfigItem extends ConfigItem {
     public void addCreateArgs(DockerLauncher launcher,
                               ArgumentListBuilder args,
                               AbstractBuild build) {
-        args.add("-m", Utils.resolveVariables(
-                build.getBuildVariableResolver(), memory).toUpperCase());
+        args.add("-m", Utils.resolveVariables(launcher, memory).toUpperCase());
     }
 
     @Extension

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/NvidiaGpuDevicesConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/NvidiaGpuDevicesConfigItem.java
@@ -81,7 +81,7 @@ public class NvidiaGpuDevicesConfigItem extends CustomConfigItem {
                 throw new RuntimeException(e);
             }
         } else {
-            args.addKeyValuePair("", ENV_VAR_NAME, getResolvedValue(build),
+            args.addKeyValuePair("", ENV_VAR_NAME, getResolvedValue(launcher),
                                  false);
         }
     }

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/UserConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/UserConfigItem.java
@@ -119,9 +119,9 @@ public class UserConfigItem extends ConfigItem {
     public void postCreate(DockerLauncher launcher,
                            AbstractBuild build) throws IOException, InterruptedException {
         if (!isExisting() && !"root".equals(username)) {
-            String gid = Utils.resolveVariables(build, this.gid);
-            String uid = Utils.resolveVariables(build, this.uid);
-            String username = Utils.resolveVariables(build, this.username);
+            String gid = Utils.resolveVariables(launcher, this.gid);
+            String uid = Utils.resolveVariables(launcher, this.uid);
+            String username = Utils.resolveVariables(launcher, this.username);
 
             ArgumentListBuilder groupAddArgs = new ArgumentListBuilder();
             groupAddArgs.add("groupadd", "-g", gid, username);
@@ -143,7 +143,7 @@ public class UserConfigItem extends ConfigItem {
     public void addRunArgs(DockerLauncher launcher,
                            ArgumentListBuilder args,
                            AbstractBuild build) {
-        args.add("--user", Utils.resolveVariables(build, username));
+        args.add("--user", Utils.resolveVariables(launcher, username));
     }
 
     @Extension

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/VolumeConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/VolumeConfiguration.java
@@ -24,10 +24,10 @@
 
 package com.gpuopenanalytics.jenkins.remotedocker.config;
 
+import com.gpuopenanalytics.jenkins.remotedocker.DockerLauncher;
 import com.gpuopenanalytics.jenkins.remotedocker.Utils;
 import hudson.Extension;
 import hudson.ExtensionPoint;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.ArgumentListBuilder;
@@ -69,10 +69,10 @@ public class VolumeConfiguration extends AbstractDescribableImpl<VolumeConfigura
         return readOnly;
     }
 
-    private String getDockerArgument(AbstractBuild build) {
+    private String getDockerArgument(DockerLauncher launcher) {
         String readType = readOnly ? READ_ONLY_FLAG : READ_WRITE_FLAG;
-        return String.join(":", Utils.resolveVariables(build, hostPath),
-                           Utils.resolveVariables(build, destPath),
+        return String.join(":", Utils.resolveVariables(launcher, hostPath),
+                           Utils.resolveVariables(launcher, destPath),
                            readType);
     }
 
@@ -88,8 +88,8 @@ public class VolumeConfiguration extends AbstractDescribableImpl<VolumeConfigura
         }
     }
 
-    public void addArgs(ArgumentListBuilder args, AbstractBuild build) {
-        args.add("-v", getDockerArgument(build));
+    public void addArgs(ArgumentListBuilder args, DockerLauncher launcher) {
+        args.add("-v", getDockerArgument(launcher));
     }
 
     @Extension

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerFileConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerFileConfiguration.java
@@ -141,27 +141,27 @@ public class DockerFileConfiguration extends AbstractDockerConfiguration {
         if (StringUtils.isNotEmpty(buildArgs)) {
             Properties props = Utils.parsePropertiesString(buildArgs);
             for (String key : props.stringPropertyNames()) {
-                String value = Utils.resolveVariables(build,
+                String value = Utils.resolveVariables(launcher,
                                                       props.getProperty(key));
                 args.add("--build-arg");
                 args.addKeyValuePair("", key, value, false);
             }
         }
         if (StringUtils.isNotEmpty(tag)) {
-            image = Utils.resolveVariables(build, tag);
+            image = Utils.resolveVariables(launcher, tag);
         } else {
             image = UUID.randomUUID().toString();
         }
         args.add("-t", image);
 
-        String dockerFilePath = Utils.resolveVariables(build, dockerFile);
+        String dockerFilePath = Utils.resolveVariables(launcher, dockerFile);
         Path path = Paths.get(dockerFilePath);
         if (!path.isAbsolute()) {
             path = Paths.get(localWorkspace, dockerFilePath);
         }
         args.add("-f", path.toString());
         if (StringUtils.isNotEmpty(context)) {
-            args.add(Utils.resolveVariables(build, context));
+            args.add(Utils.resolveVariables(launcher, context));
         } else {
             args.add(build.getWorkspace().getRemote());
         }
@@ -182,7 +182,7 @@ public class DockerFileConfiguration extends AbstractDockerConfiguration {
         getConfigItemList().stream()
                 .forEach(item -> item.addCreateArgs(launcher, args, build));
         getVolumes().stream()
-                .forEach(item -> item.addArgs(args, build));
+                .forEach(item -> item.addArgs(args, launcher));
         args.add(image);
     }
 

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
@@ -85,8 +85,7 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
                            String localWorkspace) throws IOException, InterruptedException {
         if (isForcePull()) {
             ArgumentListBuilder args = new ArgumentListBuilder();
-            String image = Utils.resolveVariables(launcher.getBuild(),
-                                                  getImage());
+            String image = Utils.resolveVariables(launcher, getImage());
             args.add("docker", "pull", image);
             Launcher.ProcStarter proc = launcher.executeCommand(args)
                     .stderr(launcher.getListener().getLogger());
@@ -107,9 +106,9 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
         getConfigItemList().stream()
                 .forEach(item -> item.addCreateArgs(launcher, args, build));
         getVolumes().stream()
-                .forEach(item -> item.addArgs(args, build));
+                .forEach(item -> item.addArgs(args, launcher));
 
-        args.add(Utils.resolveVariables(build, getImage()));
+        args.add(Utils.resolveVariables(launcher, getImage()));
     }
 
     @Extension

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/SideDockerConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/SideDockerConfiguration.java
@@ -75,7 +75,7 @@ public class SideDockerConfiguration extends AbstractDescribableImpl<SideDockerC
     public void addCreateArgs(DockerLauncher launcher,
                               ArgumentListBuilder args,
                               AbstractBuild build) {
-        args.add("--name", Utils.resolveVariables(build, name));
+        args.add("--name", Utils.resolveVariables(launcher, name));
         dockerConfiguration.addCreateArgs(launcher, args, build);
     }
 


### PR DESCRIPTION
Fixes #8 

Uses the build's `EnvVars` instead of variable resolver. Some refactoring was required to get the required `AbstractBuild` and `TaskListener` available. I used the `DockerLauncher` instance for both.