### PR TITLE
[REVIEW] FEA Add support for retrying docker pulls on failure

### DIFF
--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
@@ -109,17 +109,18 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
                         .stderr(launcher.getListener().getLogger())
                         .stdout(launcher.getListener());
             status = proc.join();
-
+            status = 1;
             while (retries < numRetries && status != 0) {
-                String message = "Docker pull failed, retry " + Integer.toString(numRetries) +
+                retries += 1;
+                String message = "Docker pull failed, retry " + Integer.toString(retries) +
                                  " of " + maxRetries + "...";
                 launcher.getListener().getLogger().println(message);
-                retries += 1;
 
                 proc = launcher.executeCommand(args)
                         .stderr(launcher.getListener().getLogger())
                         .stdout(launcher.getListener());
                 status = proc.join();
+                status = 1;
             }
 
             if (status != 0) {

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
@@ -113,10 +113,10 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
         if (isForcePull()) {
             ArgumentListBuilder args = new ArgumentListBuilder();
             String image = Utils.resolveVariables(launcher, getImage());
-	    String maxRetries = Utils.resolveVariables(launcher, getRetries());
-	    args.add("docker", "pull", image);
-	    int numRetries = Integer.parseInt(maxRetries);
-	    int retries = 0;
+            String maxRetries = Utils.resolveVariables(launcher, getRetries());
+            args.add("docker", "pull", image);
+            int numRetries = Integer.parseInt(maxRetries);
+            int retries = 0;
             int status;
 
             Launcher.ProcStarter proc = launcher.executeCommand(args)
@@ -124,7 +124,7 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
                         .stdout(launcher.getListener());
             status = proc.join();
 
-	    while (retries < numRetries && status != 0) {
+            while (retries < numRetries && status != 0) {
                 launcher.getListener().getLogger().println("Docker pull failed, retrying...");
                 retries += 1;
 
@@ -132,9 +132,9 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
                         .stderr(launcher.getListener().getLogger())
                         .stdout(launcher.getListener());
                 status = proc.join();
-	    }
+            }
 
-	    if (status != 0) {
+            if (status != 0) {
                 throw new IOException("Could not pull image: " + image);
             }
         }

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
@@ -47,36 +47,22 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
 
     private final String image;
     private final String maxRetries;
-    private final boolean pullImage;
+    private final boolean forcePull;
 
     @DataBoundConstructor
     public DockerImageConfiguration(List<ConfigItem> configItemList,
                                     List<VolumeConfiguration> volumes,
                                     String image,
-                                    ForcePull forcePull) {
+                                    boolean forcePull,
+                                    String maxRetries) {
         super(configItemList, volumes);
         this.image = image;
-        if (forcePull != null ) {
-            this.maxRetries = forcePull.maxRetries;
-            this.pullImage = true;
-        }
-        else {
-            this.maxRetries = "0";
-            this.pullImage = false;
-        }
+        this.forcePull = forcePull;
+        this.maxRetries = maxRetries;
     }
     
-    public static class ForcePull {
-        private String maxRetries;
-
-        @DataBoundConstructor
-        public ForcePull(String maxRetries) {
-            this.maxRetries = maxRetries;
-        }
-    }
-
     public boolean isForcePull() {
-        return pullImage;
+        return forcePull;
     }
 
     public String getImage() {
@@ -99,7 +85,7 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
         for (VolumeConfiguration volume : getVolumes()) {
             volume.validate();
         }
-	if (StringUtils.isEmpty(maxRetries)) {
+	if (StringUtils.isEmpty(maxRetries) && isForcePull()) {
             throw new Descriptor.FormException("Max Retries cannot be empty", "maxRetries");
 	}
 	if (!StringUtils.isNumeric(maxRetries)) {

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
@@ -123,7 +123,6 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
                         .stderr(launcher.getListener().getLogger())
                         .stdout(launcher.getListener());
             status = proc.join();
-            status = 1;
 
 	    while (retries < numRetries && status != 0) {
                 launcher.getListener().getLogger().println("Docker pull failed, retrying...");
@@ -133,7 +132,6 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
                         .stderr(launcher.getListener().getLogger())
                         .stdout(launcher.getListener());
                 status = proc.join();
-		status = 1;
 	    }
 
 	    if (status != 0) {

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
@@ -109,7 +109,7 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
                         .stderr(launcher.getListener().getLogger())
                         .stdout(launcher.getListener());
             status = proc.join();
-            status = 1;
+            
             while (retries < numRetries && status != 0) {
                 retries += 1;
                 String message = "Docker pull failed, retry " + Integer.toString(retries) +
@@ -120,7 +120,6 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
                         .stderr(launcher.getListener().getLogger())
                         .stdout(launcher.getListener());
                 status = proc.join();
-                status = 1;
             }
 
             if (status != 0) {

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration.java
@@ -111,7 +111,9 @@ public class DockerImageConfiguration extends AbstractDockerConfiguration {
             status = proc.join();
 
             while (retries < numRetries && status != 0) {
-                launcher.getListener().getLogger().println("Docker pull failed, retrying...");
+                String message = "Docker pull failed, retry " + Integer.toString(numRetries) +
+                                 " of " + maxRetries + "...";
+                launcher.getListener().getLogger().println(message);
                 retries += 1;
 
                 proc = launcher.executeCommand(args)

--- a/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration/advanced-config.jelly
+++ b/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration/advanced-config.jelly
@@ -30,5 +30,11 @@
         <f:checkbox/>
     </f:entry>
 
+    <f:optionalBlock field="forcePull" title="Force pull">
+        <f:entry title="Max pull retries" field="maxRetries">
+            <f:textbox default="1"/>
+        </f:entry>
+    </f:optionalBlock>
+
 </j:jelly>
 

--- a/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration/advanced-config.jelly
+++ b/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration/advanced-config.jelly
@@ -26,13 +26,11 @@
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
 
-    <f:entry title="Force pull" field="forcePull">
-        <f:checkbox default="true"/>
-    </f:entry>
-
-    <f:entry title="Max pull retries" field="maxRetries">
-        <f:textbox default="1"/>
-    </f:entry>
+    <f:optionalBlock field="forcePull" title="Force Pull" inline="true" checked="${instance.forcePull}">
+        <f:entry title="Max Retries" field="maxRetries">
+            <f:textbox default="1"/>
+        </f:entry>
+    </f:optionalBlock>
 
 </j:jelly>
 

--- a/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration/advanced-config.jelly
+++ b/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration/advanced-config.jelly
@@ -26,11 +26,7 @@
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
 
-    <f:entry title="Force pull" field="forcePull">
-        <f:checkbox/>
-    </f:entry>
-
-    <f:optionalBlock field="forcePull" title="Force pull">
+    <f:optionalBlock field="forcePull" title="Force pull" checked="${instance.forcePull}">
         <f:entry title="Max pull retries" field="maxRetries">
             <f:textbox default="1"/>
         </f:entry>

--- a/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration/advanced-config.jelly
+++ b/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/job/DockerImageConfiguration/advanced-config.jelly
@@ -26,11 +26,13 @@
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
 
-    <f:optionalBlock field="forcePull" title="Force pull" checked="${instance.forcePull}">
-        <f:entry title="Max pull retries" field="maxRetries">
-            <f:textbox default="1"/>
-        </f:entry>
-    </f:optionalBlock>
+    <f:entry title="Force pull" field="forcePull">
+        <f:checkbox default="true"/>
+    </f:entry>
+
+    <f:entry title="Max pull retries" field="maxRetries">
+        <f:textbox default="1"/>
+    </f:entry>
 
 </j:jelly>
 


### PR DESCRIPTION
# Summary

* Replaced `forcePull` jelly block with an optionalBlock with an encapsulated `maxRetries` field
* Added `ForcePull` class and accompanying constructor that reads the input
* `DockerImageConfiguration` constructor has been updated to use the new `ForcePull` class
* Added a loop that retries the `docker pull` command based on `maxRetries` field
* Added a `FormException` for possible invalid inputs


# Testing Screenshots

Note: In the examples with retries, I had it hardcoded to "Fail" the docker pull to force the retries to happen, you can see in the console output that the images are downloaded/up-to-date.



## Force Pull Off

<img width="1240" alt="Screen Shot 2020-10-22 at 4 59 39 PM" src="https://user-images.githubusercontent.com/18494947/96929671-7cfd1280-1488-11eb-9b02-dd7170afc4cf.png">

## Force Pull On : Retries = 0

<img width="1521" alt="Screen Shot 2020-10-22 at 5 06 42 PM" src="https://user-images.githubusercontent.com/18494947/96929972-fac11e00-1488-11eb-9a92-d6aeea34c7c2.png">

## Force Pull On : Retries = 5

<img width="1491" alt="Screen Shot 2020-10-22 at 5 07 44 PM" src="https://user-images.githubusercontent.com/18494947/96930088-25ab7200-1489-11eb-8ef5-5173a551226f.png">

## Invalid Input Errors

<img width="1657" alt="Screen Shot 2020-10-22 at 5 08 42 PM" src="https://user-images.githubusercontent.com/18494947/96930148-41af1380-1489-11eb-836c-07b917d62834.png">

<img width="1651" alt="Screen Shot 2020-10-22 at 5 09 46 PM" src="https://user-images.githubusercontent.com/18494947/96930257-67d4b380-1489-11eb-8fcf-70127d51f22d.png">

## Successful Pull : Retries = 3 (Removed hardcoded failure)

<img width="1341" alt="Screen Shot 2020-10-22 at 5 11 56 PM" src="https://user-images.githubusercontent.com/18494947/96930448-b5512080-1489-11eb-88d9-c20cd61b815f.png">


