### PR TITLE
Add support for docker login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <version>3.0.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.16</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/AbstractDockerLauncher.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/AbstractDockerLauncher.java
@@ -26,6 +26,7 @@ package com.gpuopenanalytics.jenkins.remotedocker;
 
 import com.gpuopenanalytics.jenkins.remotedocker.job.DockerConfiguration;
 import hudson.EnvVars;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Proc;
 import hudson.util.ArgumentListBuilder;
@@ -45,6 +46,7 @@ public abstract class AbstractDockerLauncher extends Launcher.DecoratedLauncher 
 
     private DockerState dockerState;
     private DockerVersion version;
+    private FilePath loginTempDir;
 
     protected AbstractDockerLauncher(@Nonnull Launcher launcher) {
         super(launcher);
@@ -167,6 +169,9 @@ public abstract class AbstractDockerLauncher extends Launcher.DecoratedLauncher 
         if (!"docker".equals(args.toList().get(0))) {
             args.prepend("docker");
         }
+        if (loginTempDir != null) {
+            args.prepend("env", "HOME=" + loginTempDir.getRemote());
+        }
         return getInner().launch()
                 //TODO I think we should pass something here
                 //.envs()
@@ -223,6 +228,7 @@ public abstract class AbstractDockerLauncher extends Launcher.DecoratedLauncher 
      */
     void configure(DockerState dockerState) {
         this.dockerState = dockerState;
+        configureTempDir(dockerState.getLoginTempDir());
     }
 
     /**
@@ -232,5 +238,9 @@ public abstract class AbstractDockerLauncher extends Launcher.DecoratedLauncher 
      */
     protected DockerState getDockerState() {
         return dockerState;
+    }
+
+    public void configureTempDir(FilePath loginTempDir) {
+        this.loginTempDir = loginTempDir;
     }
 }

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/pipeline/DockerLauncherDecorator.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/pipeline/DockerLauncherDecorator.java
@@ -24,6 +24,7 @@
 
 package com.gpuopenanalytics.jenkins.remotedocker.pipeline;
 
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.gpuopenanalytics.jenkins.remotedocker.AbstractDockerLauncher;
 import com.gpuopenanalytics.jenkins.remotedocker.DockerState;
 import com.gpuopenanalytics.jenkins.remotedocker.job.DockerConfiguration;
@@ -34,6 +35,7 @@ import hudson.Proc;
 import hudson.model.Node;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 
@@ -47,17 +49,20 @@ public class DockerLauncherDecorator extends LauncherDecorator implements Serial
     private DockerConfiguration dockerConfiguration;
     private EnvVars environment;
     private String workspaceOverride;
+    private UsernamePasswordCredentials credentials;
 
     public DockerLauncherDecorator(boolean debug,
                                    DockerState dockerState,
                                    DockerConfiguration dockerConfiguration,
                                    EnvVars environment,
-                                   String workspaceOverride) {
+                                   String workspaceOverride,
+                                   @Nullable UsernamePasswordCredentials credentials) {
         this.debug = debug;
         this.dockerState = dockerState;
         this.dockerConfiguration = dockerConfiguration;
         this.environment = environment;
         this.workspaceOverride = workspaceOverride;
+        this.credentials=credentials;
     }
 
     @Nonnull

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/pipeline/RemoteDockerStep.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/pipeline/RemoteDockerStep.java
@@ -57,12 +57,16 @@ public class RemoteDockerStep extends Step {
     private List<SideDockerConfiguration> sideContainers;
     private String workspaceOverride;
     private Boolean removeContainers = true;
+    private String registryUrl;
+    private String credentialsId;
 
     @DataBoundConstructor
     public RemoteDockerStep(boolean debug,
                             AbstractDockerConfiguration main,
                             List<SideDockerConfiguration> sideContainers,
-                            String workspaceOverride) {
+                            String workspaceOverride,
+                            String registryUrl,
+                            String credentialsId) {
         this.debug = debug;
         this.main = main;
         this.sideContainers = ImmutableList.copyOf(
@@ -70,6 +74,8 @@ public class RemoteDockerStep extends Step {
                         .orElse(Collections.emptyList()));
         this.workspaceOverride = StringUtils.isNotEmpty(
                 workspaceOverride) ? workspaceOverride : null;
+        this.registryUrl = registryUrl;
+        this.credentialsId = credentialsId;
     }
 
     @Override
@@ -100,6 +106,14 @@ public class RemoteDockerStep extends Step {
 
     public String getWorkspaceOverride() {
         return workspaceOverride;
+    }
+
+    public String getRegistryUrl() {
+        return registryUrl;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
     }
 
     @Extension

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/pipeline/RemoteDockerStepExecution.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/pipeline/RemoteDockerStepExecution.java
@@ -72,7 +72,8 @@ public class RemoteDockerStepExecution extends StepExecution {
                 remoteDockerStep.getWorkspaceOverride(),
                 remoteDockerStep.getMain(),
                 remoteDockerStep.getSideContainers(),
-                null, null);
+                remoteDockerStep.getRegistryUrl(),
+                remoteDockerStep.getCredentialsId());
         buildWrapper.setRemoveContainers(remoteDockerStep.isRemoveContainers());
 
         Launcher launcher = getContext().get(Launcher.class);
@@ -142,7 +143,7 @@ public class RemoteDockerStepExecution extends StepExecution {
 
             @Override
             public EnvVars getEnvironment() {
-                return null;
+                return new EnvVars();
             }
 
             @Override

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/pipeline/RemoteDockerStepExecution.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/pipeline/RemoteDockerStepExecution.java
@@ -24,6 +24,8 @@
 
 package com.gpuopenanalytics.jenkins.remotedocker.pipeline;
 
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.gpuopenanalytics.jenkins.remotedocker.AbstractDockerLauncher;
 import com.gpuopenanalytics.jenkins.remotedocker.DockerState;
 import com.gpuopenanalytics.jenkins.remotedocker.RemoteDockerBuildWrapper;
 import com.gpuopenanalytics.jenkins.remotedocker.SimpleDockerLauncher;
@@ -32,6 +34,7 @@ import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.LauncherDecorator;
+import hudson.Proc;
 import org.jenkinsci.plugins.workflow.steps.BodyExecution;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.BodyInvoker;
@@ -68,12 +71,15 @@ public class RemoteDockerStepExecution extends StepExecution {
                 remoteDockerStep.isDebug(),
                 remoteDockerStep.getWorkspaceOverride(),
                 remoteDockerStep.getMain(),
-                remoteDockerStep.getSideContainers());
+                remoteDockerStep.getSideContainers(),
+                null, null);
         buildWrapper.setRemoveContainers(remoteDockerStep.isRemoveContainers());
 
         Launcher launcher = getContext().get(Launcher.class);
         FilePath workspace = getContext().get(FilePath.class);
         EnvVars environment = getContext().get(EnvVars.class);
+        UsernamePasswordCredentials credentials = getContext().get(
+                UsernamePasswordCredentials.class);
 
         SimpleDockerLauncher simpleDockerLauncher = new SimpleDockerLauncher(
                 launcher, buildWrapper.isDebug(), environment, buildWrapper);
@@ -87,7 +93,8 @@ public class RemoteDockerStepExecution extends StepExecution {
                 dockerState,
                 remoteDockerStep.getMain(),
                 environment,
-                remoteDockerStep.getWorkspaceOverride());
+                remoteDockerStep.getWorkspaceOverride(),
+                credentials);
 
         LauncherDecorator launcherDecorator = BodyInvoker.mergeLauncherDecorators(
                 getContext().get(LauncherDecorator.class),
@@ -108,7 +115,7 @@ public class RemoteDockerStepExecution extends StepExecution {
         }
         if (dockerState != null) {
             Launcher launcher = getContext().get(Launcher.class);
-            dockerState.tearDown(launcher);
+            dockerState.tearDown(createLauncher(launcher, dockerState));
         }
 
     }
@@ -122,6 +129,27 @@ public class RemoteDockerStepExecution extends StepExecution {
     @Override
     public String getStatus() {
         return null;
+    }
+
+    private static AbstractDockerLauncher createLauncher(Launcher launcher,
+                                                         DockerState dockerState) {
+        return new AbstractDockerLauncher(launcher, dockerState) {
+            @Override
+            public Proc dockerExec(ProcStarter starter,
+                                   boolean addRunArgs) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public EnvVars getEnvironment() {
+                return null;
+            }
+
+            @Override
+            public boolean isDebug() {
+                return dockerState.isDebug();
+            }
+        };
     }
 
     /**
@@ -140,7 +168,7 @@ public class RemoteDockerStepExecution extends StepExecution {
         public void onSuccess(StepContext context, Object result) {
             try {
                 Launcher launcher = context.get(Launcher.class);
-                dockerState.tearDown(launcher);
+                dockerState.tearDown(createLauncher(launcher, dockerState));
                 context.onSuccess(result);
             } catch (IOException | InterruptedException e) {
                 throw new RuntimeException(e);
@@ -151,7 +179,7 @@ public class RemoteDockerStepExecution extends StepExecution {
         public void onFailure(StepContext context, Throwable t) {
             try {
                 Launcher launcher = context.get(Launcher.class);
-                dockerState.tearDown(launcher);
+                dockerState.tearDown(createLauncher(launcher, dockerState));
                 context.onFailure(t);
             } catch (IOException | InterruptedException e) {
                 throw new RuntimeException(e);

--- a/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/RemoteDockerBuildWrapper/config.jelly
+++ b/src/main/resources/com/gpuopenanalytics/jenkins/remotedocker/RemoteDockerBuildWrapper/config.jelly
@@ -24,7 +24,8 @@
   -->
 
 <j:jelly xmlns:j="jelly:core"
-         xmlns:f="/lib/form">
+         xmlns:f="/lib/form"
+         xmlns:c="/lib/credentials">
 
     <f:dropdownDescriptorSelector title="Build container"
                                   field="dockerConfiguration"
@@ -43,9 +44,19 @@
     <f:entry title="Debug" field="debug">
         <f:checkbox/>
     </f:entry>
-    <f:optionalBlock name="workspaceOverrideOptional" title="Override workspace mount" inline="true" checked="${!empty(instance.workspaceOverride)}">
+    <f:optionalBlock name="workspaceOverrideOptional" title="Override workspace mount" inline="true"
+                     checked="${!empty(instance.workspaceOverride)}">
         <f:entry title="Workspace path" field="workspaceOverride">
             <f:textbox/>
+        </f:entry>
+    </f:optionalBlock>
+    <f:optionalBlock name="dockerLoginOptional" title="Docker Login" inline="true"
+                     checked="${!empty(instance.dockerRegistryUrl) or !empty(instance.credentialsId)}">
+        <f:entry title="Registry Url" field="dockerRegistryUrl">
+            <f:textbox/>
+        </f:entry>
+        <f:entry title="Credentials" field="credentialsId">
+            <c:select/>
         </f:entry>
     </f:optionalBlock>
 


### PR DESCRIPTION
Closes #33 

Support for `docker login` is handled by executing docker commands prepended by `env HOME=<dir>` so that the credentials stored by docker are isolated per job. Per https://docs.docker.com/engine/reference/commandline/login/#privileged-user-requirement logins are stored in `$HOME/.docker/config.json`. The directory used is provided by `WorkspaceList.tempDir(workspace)` which returns a temporary directory based on the workspace.

![Screen Shot 2020-10-23 at 2 56 43 PM](https://user-images.githubusercontent.com/3107146/97043934-40412200-1541-11eb-8fbd-e68ca59f57c2.png)