### PR TITLE
[REVIEW] FEA Support Multi-Instance GPUs

### DIFF
--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/NvidiaGpuDevicesConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/NvidiaGpuDevicesConfigItem.java
@@ -37,6 +37,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -78,7 +80,7 @@ public class NvidiaGpuDevicesConfigItem extends CustomConfigItem {
         String value;
         if ("executor".equals(getValue())) {
             String executorNum = launcher.getEnvironment().get("EXECUTOR_NUMBER");
-            String nvidiasmiOutput = executeWithOutput(launcher.getInner(), "nvidia-smi", "-L"); 
+            String nvidiasmiOutput = executeWithOutput(launcher.getInner(), "nvidia-smi", "-L");
             if (isMIG(nvidiasmiOutput)) {
                 value = getMIG(nvidiasmiOutput, executorNum);
             } else {
@@ -134,7 +136,7 @@ public class NvidiaGpuDevicesConfigItem extends CustomConfigItem {
     }
 
     private boolean isMIG(String output) {
-        Pattern pattern = Pattern.compile("(MIG-GPU-[a-f0-9\-\/]+)");
+        Pattern pattern = Pattern.compile("(MIG-GPU-[a-f0-9\\-\\/]+)");
         Matcher m = pattern.matcher(output);
 
         if (m.find()) {
@@ -144,13 +146,14 @@ public class NvidiaGpuDevicesConfigItem extends CustomConfigItem {
     }
 
     private String getMIG(String output, String executor) {
+        int executorNum = Integer.parseInt(executor);
         List<String> uuids = new ArrayList<String>();
-        Pattern pattern = Pattern.compile("(MIG-GPU-[a-f0-9\-\/]+)");
+        Pattern pattern = Pattern.compile("(MIG-GPU-[a-f0-9\\-\\/]+)");
         Matcher m = pattern.matcher(output);
 
         while (m.find()) {
             uuids.add(m.group());
         }
-        return uuids[executor];
+        return uuids.get(executorNum);
     }
 }

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/NvidiaGpuDevicesConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/NvidiaGpuDevicesConfigItem.java
@@ -67,9 +67,27 @@ public class NvidiaGpuDevicesConfigItem extends CustomConfigItem {
     @Override
     public void addCreateArgs(AbstractDockerLauncher launcher,
                               ArgumentListBuilder args) {
+        boolean isMIG() {
+            if (executeWithOutput(launcher.getInner(), "nvidia-smi", "-L", "|", "grep", "-i", "MIG") != "") {
+                 return true;
+            }
+            return false;
+        }
+
+        String getMIG(String executor) {
+            String uuid = executeWithOutput(launcher.getInner(), "nvidia-smi", "-L", "|", "grep", 
+                                            "-i", "MIG", "|", "sed", "-n", executor);
+            return uuid;
+        }
+
         String value;
         if ("executor".equals(getValue())) {
-            value = launcher.getEnvironment().get("EXECUTOR_NUMBER");
+            String executorNum = launcher.getEnvironment().get("EXECUTOR_NUMBER");
+            if (isMIG()) {
+                value = getMIG(executorNum));
+            } else {
+                value = launcher.getEnvironment().get("EXECUTOR_NUMBER");
+            }
         } else {
             value = getResolvedValue(launcher);
         }

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/NvidiaGpuDevicesConfigItem.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/config/NvidiaGpuDevicesConfigItem.java
@@ -79,7 +79,7 @@ public class NvidiaGpuDevicesConfigItem extends CustomConfigItem {
             if (isMIG(launcher)) {
                 value = getMIG(launcher, executorNum);
             } else {
-                value = launcher.getEnvironment().get("EXECUTOR_NUMBER");
+                value = executorNum;
             }
         } else {
             value = getResolvedValue(launcher);


### PR DESCRIPTION
Small code refactor to support MIGs. Checks if there are MIG UUID's that exist on the machine, if there are, we convert the value passed to docker from a `GPU Index` to a `MIG UUID`

These jobs are running on 2 GPUs with MIG support. Each GPU has 7 compute instances with 5GB each.

<img width="364" alt="Screen Shot 2020-11-12 at 1 25 43 PM" src="https://user-images.githubusercontent.com/18494947/98982381-52353580-24ed-11eb-9af2-cfd9e5795aaf.png">
