### PR TITLE
Remove double network for side containers

### DIFF
--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/DockerNetwork.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/DockerNetwork.java
@@ -52,7 +52,9 @@ public class DockerNetwork {
      */
     public static DockerNetwork create(AbstractDockerLauncher launcher) throws IOException, InterruptedException {
         ArgumentListBuilder args = new ArgumentListBuilder();
-        args.add("docker", "network", "create", UUID.randomUUID().toString());
+        args.add("docker", "network", "create", "-d", "bridge",
+                 UUID.randomUUID().toString());
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         int status = launcher.executeCommand(args)
                 .stdout(baos)

--- a/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/DockerState.java
+++ b/src/main/java/com/gpuopenanalytics/jenkins/remotedocker/DockerState.java
@@ -249,11 +249,14 @@ public class DockerState implements Serializable {
 
         //TODO Set name? Maybe with build.toString().replaceAll("^\\w", "_")
         ArgumentListBuilder args = new ArgumentListBuilder()
-                .add("run", "-t", "-d")
-                //Add bridge network for internet access
-                .add("--network", "bridge");
-        //Add inter-container network if needed
-        network.ifPresent(net -> net.addArgs(args));
+                .add("run", "-t", "-d");
+        if (network.isPresent()) {
+            //Add inter-container network
+            network.get().addArgs(args);
+        } else {
+            //Add bridge network for internet access
+            args.add("--network", "bridge");
+        }
 
         if (isMain) {
             String secondaryTempPath = WorkspaceList.tempDir(workspace)


### PR DESCRIPTION
Fixes #45 

1) Use the DockerNetwork if it exists, otherwise use the bridge network
2) Explicitly create a DockerNetwork with the bridge driver